### PR TITLE
Fix apiVersion field

### DIFF
--- a/devstats-helm-example/templates/devstats-grafana.yaml
+++ b/devstats-helm-example/templates/devstats-grafana.yaml
@@ -4,7 +4,7 @@
 {{- range $index, $_ := .Values.projects -}}
 {{- if and (or (eq ($index|int) ($root.Values.indexGrafanasFrom|int)) (gt ($index|int) ($root.Values.indexGrafanasFrom|int))) (lt ($index|int) ($root.Values.indexGrafanasTo|int)) -}}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: '{{ $root.Values.grafanaPodName }}-{{ .proj }}'


### PR DESCRIPTION
A minor fix of `apiVersion` which is suppose to be `apps/v1` for Kubernetes v1.9 and up.